### PR TITLE
Update Drone pipeline to use manifest

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -14,8 +14,59 @@ steps:
       password:
         from_secret: docker_password
       repo: rancher/systemd-node
-      tag: ${DRONE_TAG}
+      tag: "${DRONE_TAG}-amd64"
     when:
       instance:
         - drone-publish.rancher.io
       event: tag
+---
+kind: pipeline
+name: arm64
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+  - name: docker
+    image: plugins/docker
+    settings:
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+      repo: rancher/systemd-node
+      tag: "${DRONE_TAG}-arm64"
+    when:
+      instance:
+        - drone-publish.rancher.io
+      event: tag
+---
+kind: pipeline
+name: manifest
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: manifest
+  image: plugins/manifest
+  settings:
+    username:
+      from_secret: docker_username
+    password:
+      from_secret: docker_password
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    target: "rancher/systemd-node:${DRONE_TAG}"
+    template: "rancher/systemd-node:${DRONE_TAG}-ARCH"
+  when:
+    instance:
+      - drone-publish.rancher.io
+    event: tag
+
+depends_on:
+  - amd64
+  - arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,6 @@ RUN cd /etc/systemd/system/ && \
         cloud-init.service \
         cloud-config.service \
         cloud-final.service
- 
-# Add k9s
-RUN curl -fL https://github.com/derailed/k9s/releases/download/v0.26.3/k9s_Linux_x86_64.tar.gz | tar xvzf - -C /usr/bin k9s
 
 # Dummy services
 COPY noop.service noop.target /etc/systemd/system/


### PR DESCRIPTION
We need both arm64 and adm64 images of `systemd-node` for Rancher integration tests, so I updated the Drone pipeline to generate images for both architectures.