### PR TITLE
Support cgroupsv2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,9 @@ RUN cd /etc/systemd/system/ && \
         cloud-config.service \
         cloud-final.service
 
+COPY prepare-cgroups-v2.sh /
+RUN chmod +x /prepare-cgroups-v2.sh
+
 # Dummy services
 COPY noop.service noop.target /etc/systemd/system/
 COPY DataSourceNoCloudNoMedia.py /usr/lib/python3.6/site-packages/cloudinit/sources

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,13 @@ COPY default_userdata /var/lib/cloud/seed/nocloud/user-data
 COPY env /etc/bash.bashrc.local
 RUN touch /var/lib/cloud/seed/nocloud/meta-data /etc/fstab
 
+COPY default_env /etc/default/rke2-server
+COPY default_env /etc/default/rke2-agent
+COPY default_env /etc/default/k3s
+COPY default_env /etc/default/k3s-agent
+COPY default_env /etc/default/rancher-system-agent
+
 VOLUME /var/lib/kubelet
 VOLUME /var/lib/rancher
 CMD ["/usr/lib/systemd/systemd", "--unit=noop.target", "--show-status=true"]
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# systemd-node
+
+systemd-node is a container image designed to allow the simulated running of K3s and RKE2 within a Kubernetes Pod.
+
+Its primary usage is in rancher/rancher for provisioning tests

--- a/default_env
+++ b/default_env
@@ -1,0 +1,2 @@
+INVOCATION_ID=
+

--- a/env
+++ b/env
@@ -1,13 +1,12 @@
-if [ -z "$KUBECONFIG" ]; then
-    if [ -e /etc/rancher/rke2 ]; then
-        export KUBECONFIG=/etc/rancher/rke2/rke2.yaml
-    fi
-    if [ -e /etc/rancher/k3s ]; then
-        export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
-    fi
-fi
 if [ -d /var/lib/rancher/rke2/bin ]; then
     export PATH="${PATH}:/var/lib/rancher/rke2/bin"
+    if [ -z "$KUBECONFIG" ]; then
+        export KUBECONFIG=/etc/rancher/rke2/rke2.yaml
+    fi
+else
+    if [ -z "$KUBECONFIG" ]; then
+        export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+    fi
 fi
 if [ -z "$CONTAINER_RUNTIME_ENDPOINT" ]; then
     export CONTAINER_RUNTIME_ENDPOINT=unix:///var/run/k3s/containerd/containerd.sock

--- a/noop.service
+++ b/noop.service
@@ -1,4 +1,5 @@
 [Service]
+ExecStartPre=/bin/sh -euc "if [ -f /sys/fs/cgroup/cgroup.controllers ]; then /prepare-cgroups-v2.sh; fi"
 ExecStart=/bin/sh -c "/usr/bin/journalctl -f | grep -v kernel:"
 ExecStopPost=/usr/bin/systemctl exit 1
 StandardInput=tty-force

--- a/prepare-cgroups-v2.sh
+++ b/prepare-cgroups-v2.sh
@@ -10,3 +10,4 @@ mkdir -p /etc/rancher/k3s/config.yaml.d
 
 echo "kubelet-arg+: \"cgroup-root=$root_cgroup\"" > /etc/rancher/rke2/config.yaml.d/49-cgroups-v2-kubelet-root.yaml
 echo "kubelet-arg+: \"cgroup-root=$root_cgroup\"" > /etc/rancher/k3s/config.yaml.d/49-cgroups-v2-kubelet-root.yaml
+

--- a/prepare-cgroups-v2.sh
+++ b/prepare-cgroups-v2.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# We must set the cgroup-root argument for the kubelet when using cgroupsv2, as otherwise, the parent kubelet will fight
+# the child kubelet and pods will never be started properly
+root_cgroup_raw=$(cat /proc/1/cgroup)
+root_cgroup_stripped="${root_cgroup_raw#0::}"
+root_cgroup=$(dirname "$root_cgroup_stripped")
+
+mkdir -p /etc/rancher/rke2/config.yaml.d
+mkdir -p /etc/rancher/k3s/config.yaml.d
+
+echo "kubelet-arg+: \"cgroup-root=$root_cgroup\"" > /etc/rancher/rke2/config.yaml.d/49-cgroups-v2-kubelet-root.yaml
+echo "kubelet-arg+: \"cgroup-root=$root_cgroup\"" > /etc/rancher/k3s/config.yaml.d/49-cgroups-v2-kubelet-root.yaml


### PR DESCRIPTION
# Issue
https://github.com/rancher/rancher/issues/46222

# Problem
When using cgroupsv2 with systemd-node + K3s/RKE2 run within a Kubernetes cluster, the "child" kubelet attempts to use the `/sys/fs/cgroups/kubepods` cgroup which is shared with the parent kubelet. This causes a conflict and the child processes can never start. The reason the entire cgroups hierarchy is exposed to the child kubelet is due to the fact that `systemd-node` must be run in privileged mode, which turns off cgroup namespacing in the kubelet.

# Solution
This PR introduces a new `prepare-cgroups-v2.sh` script which determines the actual cgroup path of the pod, and defines the `cgroup-root` argument of the child kubelet  using a config override with K3s/RKE2. This allows the child kubelet to start pods in the correct cgroup and prevents the parent kubelet from attempting to clobber the child cgroup. We must also define `INVOCATION_ID=` to force K3s/RKE2 (and the subsequent kubelet) to use cgroupfs vs. the systemd cgroup driver.
 