### PR TITLE
add a check to see if /sys and /run are 'shared' during startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ COPY prepare-cgroups-v2.sh /
 RUN chmod +x /prepare-cgroups-v2.sh
 
 # Dummy services
-COPY noop.service noop.target /etc/systemd/system/
+COPY noop.service noop.target extra-mounts.service /etc/systemd/system/
 COPY DataSourceNoCloudNoMedia.py /usr/lib/python3.13/site-packages/cloudinit/sources/
 COPY 10_datasource.cfg /etc/cloud/cloud.cfg.d/
 COPY default_userdata /var/lib/cloud/seed/nocloud/user-data
@@ -43,4 +43,3 @@ COPY default_env /etc/default/rancher-system-agent
 VOLUME /var/lib/kubelet
 VOLUME /var/lib/rancher
 CMD ["/usr/lib/systemd/systemd", "--unit=noop.target", "--show-status=true"]
-

--- a/extra-mounts.service
+++ b/extra-mounts.service
@@ -1,11 +1,15 @@
 [Unit]
-Name=Extra Mounts
-After=noop.service
+Description=Extra Mounts
 Requires=noop.service
+After=noop.service
+Before=cloud-final.service
 
 [Service]
 Type=oneshot
-ExecStart=/bin/sh -euc "echo 'Checking /sys mount propagation...'; if ! $(grep -q '/sys.*shared' /proc/self/mountinfo) ; then mount --make-shared /sys; echo '/sys mounted as shared'; else echo '/sys already shared'; fi"
-ExecStart=/bin/sh -euc "echo 'Checking /run mount propagation...'; if ! $(grep -q '/run.*shared' /proc/self/mountinfo) ; then mount --make-shared /run; echo '/run mounted as shared'; else echo '/run already shared'; fi"
+ExecStart=/bin/sh -euc "echo 'Checking /sys mount propagation...'; if ! grep -q \" /sys .* shared:\" /proc/self/mountinfo; then mount --make-shared /sys; echo '/sys mounted as shared'; else echo '/sys already shared'; fi"
+ExecStart=/bin/sh -euc "echo 'Checking /run mount propagation...'; if ! grep -q \" /run .* shared:\" /proc/self/mountinfo; then mount --make-shared /run; echo '/run mounted as shared'; else echo '/run already shared'; fi"
 StandardOutput=inherit
 StandardError=inherit
+
+[Install]
+WantedBy=multi-user.target

--- a/extra-mounts.service
+++ b/extra-mounts.service
@@ -6,8 +6,7 @@ Before=cloud-final.service
 
 [Service]
 Type=oneshot
-ExecStart=/bin/sh -euc "echo 'Checking /sys mount propagation...'; if ! grep -q \" /sys .* shared:\" /proc/self/mountinfo; then mount --make-shared /sys; echo '/sys mounted as shared'; else echo '/sys already shared'; fi"
-ExecStart=/bin/sh -euc "echo 'Checking /run mount propagation...'; if ! grep -q \" /run .* shared:\" /proc/self/mountinfo; then mount --make-shared /run; echo '/run mounted as shared'; else echo '/run already shared'; fi"
+ExecStart=/bin/sh -euc "for MOUNT in /run /sys /var/lib/kubelet ; do mount --make-rshared $MOUNT; done"
 StandardOutput=inherit
 StandardError=inherit
 

--- a/extra-mounts.service
+++ b/extra-mounts.service
@@ -1,0 +1,11 @@
+[Unit]
+Name=Extra Mounts
+After=noop.service
+Requires=noop.service
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -euc "echo 'Checking /sys mount propagation...'; if ! $(grep -q '/sys.*shared' /proc/self/mountinfo) ; then mount --make-shared /sys; echo '/sys mounted as shared'; else echo '/sys already shared'; fi"
+ExecStart=/bin/sh -euc "echo 'Checking /run mount propagation...'; if ! $(grep -q '/run.*shared' /proc/self/mountinfo) ; then mount --make-shared /run; echo '/run mounted as shared'; else echo '/run already shared'; fi"
+StandardOutput=inherit
+StandardError=inherit

--- a/noop.target
+++ b/noop.target
@@ -1,2 +1,2 @@
 [Unit]
-Requires=noop.service sshd.service cloud-final.service
+Requires=noop.service sshd.service cloud-final.service extra-mounts.service


### PR DESCRIPTION
# Problem
Failure had been happening in the december release lines in the rancher and KDM CI where any systemd-node pods that were created with calico as the CNI the cluster was failing to come up with the calico-node pods in `CreateContainerConfigError` with this error message:
```
failed to generate spec: path \\\"/sys/fs\\\" is mounted on \\\"/sys\\\" but it is not a shared mount\"
```

initially attempted to solve through passing these volumes down to the container to no avail on certain OS's (notably ubuntu, and i was able to reproduce this locally on a tumbleweed VM as well).

---

# Solution

By adding another unit to startup of `noop.target` that just checks to see if `/sys` and `/run` are marked as shared already and marks them as shared solves the issue and the pods come up fine.

This should be a benign change to most if not all operations even if they don't require those fs' to be shared. 